### PR TITLE
runtime_listen_addresses: "::" breaks on non-IPv6 hosts

### DIFF
--- a/m2ee.yaml
+++ b/m2ee.yaml
@@ -6,7 +6,7 @@ m2ee:
  admin_port: 9000
  admin_pass: mendix!
  runtime_port: 8000
- runtime_listen_addresses: "::"
+ runtime_listen_addresses: "*"
  javaopts: [
    "-Dfile.encoding=UTF-8", "-XX:MaxPermSize=128M", "-Xmx512M", "-Xms512M",
    "-Djava.io.tmpdir=/srv/mendix/data/tmp",


### PR DESCRIPTION
Set it to `*` instead.

```
 # set to * if you want to have the public runtime port accessible from
 other
 # hosts than localhost (Mendix >= 4.3.0)
 #runtime_listen_addresses: "*"
```

See: https://github.com/mendix/m2ee-tools/blob/master/examples/user-specific-m2ee.yaml